### PR TITLE
1.02

### DIFF
--- a/Changes.txt
+++ b/Changes.txt
@@ -1,6 +1,10 @@
--> Version 1.01, 2022-06-12
+-> Version 1.02, 2022-06-17
++ Report which images were synced and which were failed (only if any image failed).
++ New flags: --verbose (-v) and --verbose-auth (-vv) to display debug level data.
+
+Version 1.01, 2022-06-12
 ~ Fixed code for processing untagged images, described proper approach to deal with untagged images in Project Wiki: https://github.com/dfad1ripe/aws-ecr-cross-account-clone/wiki/Working-with-untagged-images-in-ECR
-~ Minor optimization of running docker subprocesses
+~ Minor optimization of running docker subprocesses.
 + Processed images are now removed after being pushed, not wasting disk space.
 
 Version 1.0, 2022-06-11

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ where the values in angle brackets are your actual access credentials for corres
 
 Usage:
 
-    aws-ecr-cross-account-clone.py [-h] src_profile src_region dst_profile dst_region [--days DAYS] [--require-scan]
+    aws-ecr-cross-account-clone.py [-h] src_profile src_region dst_profile dst_region [--days DAYS] [--require-scan] [--verbose | --verbose-auth]
 
 Positional arguments:
 
@@ -82,8 +82,14 @@ Optional arguments:
     -h, --help              Show the help message and exit
     --days DAYS, -d DAYS    How recent images to synchronize, in calendar days (default 30)
     --require-scan, -s      Clone only scanned images (default False)
+	--verbose, -v           More verbosity, except sensitive authentication data (default False)
+	--verbose-auth, -vv     More verbosity, including sensitive authentication data (default False)
 
 Example:
 
     aws-ecr-cross-account-clone.py src us-east-1 dst us-east-2 --days 14 --require-scan
 
+Notes about sensitive authentication data:
+
+-  `--verbose` flag enables printing varios debugging information, but hides AWS authorization tokens.
+-  `--verbose-auth` flag enables printing varios debugging information like `--verbose` flag does, including AWS authorization tokens.

--- a/ToDo.md
+++ b/ToDo.md
@@ -4,10 +4,10 @@
 
 Currently, this value is enforced to true. Should match the settings of the repo with the same name in source AWS account.
 
-## Report which images were synced and which were failed ##
-
-Currently, only numbers are reported
-
 ## Limit number of threads running simultaneously ##
 
 If we have dozens, or hundreds of images to clone, we should not start as many threads in parallel. Instead, we should limit the number of threads, adding new threads when old threads complete and join.
+
+## --include-repos and --exclude-repos parameters ##
+
+If we need to whitelist/blacklist some repositories.


### PR DESCRIPTION
Version 1.02, 2022-06-17
+ Report which images were synced and which were failed (only if any image failed).
+ New flags: --verbose (-v) and --verbose-auth (-vv) to display debug level data.